### PR TITLE
Add new line after outputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,11 +18,11 @@ def get_api_url():
         url = os.environ["GITHUB_API_URL"] + '/graphql'
     else:
         url = 'https://api.github.com/graphql'
-    
+
     return url
 
 # A simple function to use requests.post to make the API call. Note the json= section.
-def run_query(query,token): 
+def run_query(query,token):
     head=get_header(token)
     apiURL=get_api_url()
     request = requests.post(apiURL, json={'query': query}, headers=head)
@@ -34,7 +34,7 @@ def run_query(query,token):
 
 def get_alerts(repo,owner,token): #  A simple function to use requests.post to make the API call. Note the json= section.
     # TODO - get around the pagination limits for accurate total issues
-    # The GraphQL query (with a few aditional bits included) itself defined as a multi-line string.       
+    # The GraphQL query (with a few aditional bits included) itself defined as a multi-line string.
     query = """
     {
         repository(name: "REPO_NAME", owner: "REPO_OWNER") {
@@ -74,11 +74,11 @@ def main():
     owner = os.environ["GITHUB_REPOSITORY_OWNER"]
     repo = os.environ["GITHUB_REPOSITORY"]
     repoName = repo.split("/")[-1]                      #  Cleans the in-case we get 'owner/repo' format
-    
+
     # Query GitHub for full alerts breakdown
     alerts=get_alerts(repoName,owner,token)
     pp.pprint(alerts)
-    
+
     # Breakdown stats
     statsDict={"total_alerts": len(alerts)}
     statsDict['critical_alerts']=len(alerts.loc[alerts['severity'] == 'CRITICAL'])
@@ -86,16 +86,16 @@ def main():
     statsDict['moderate_alerts']=len(alerts.loc[alerts['severity'] == 'MODERATE'])
     statsDict['low_alerts']=len(alerts.loc[alerts['severity'] == 'LOW'])
     pp.pprint(statsDict)
-    
+
     # Set Outputs (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/_
     outputFile = os.environ["GITHUB_OUTPUT"]
     with open(outputFile, "a") as file:
-        file.write(f"total_alerts={statsDict['total_alerts']}")
-        file.write(f"critical_alerts={statsDict['critical_alerts']}")
-        file.write(f"high_alerts={statsDict['high_alerts']}")
-        file.write(f"moderate_alerts={statsDict['moderate_alerts']}")
-        file.write(f"low_alerts={statsDict['low_alerts']}")
-    
+        file.write(f"total_alerts={statsDict['total_alerts']}\n")
+        file.write(f"critical_alerts={statsDict['critical_alerts']}\n")
+        file.write(f"high_alerts={statsDict['high_alerts']}\n")
+        file.write(f"moderate_alerts={statsDict['moderate_alerts']}\n")
+        file.write(f"low_alerts={statsDict['low_alerts']}\n")
+
     # Create markdown summary
     summaryFile = os.environ["GITHUB_STEP_SUMMARY"]  #https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
     summary = {'Severity': ['CRITICAL','HIGH','MODERATE','LOW'], 'Open Issues': list( map(statsDict.get,['critical_alerts','high_alerts','moderate_alerts','low_alerts']))}


### PR DESCRIPTION
# Changes

GH requires to have a new line when we write to the GITHUB_OPTION file. 

Currently when some alerts are found: 
![image](https://github.com/spicyparrot/check-dependabot/assets/204105/9a814607-0de3-4924-878c-26b4b319d1c0)

I can't use the `total_alerts` output in `if: steps.alerts.outputs.total_alerts > 0` because it's a string, if I print it it looks like this
![image](https://github.com/spicyparrot/check-dependabot/assets/204105/cf7458bd-b42c-40f0-ab70-37939216176e)

Adding a new line make sure GH understands this are different outputs 
![image](https://github.com/spicyparrot/check-dependabot/assets/204105/df0db6dc-dddf-4339-b505-b3bc762cc4e8)

![image](https://github.com/spicyparrot/check-dependabot/assets/204105/8aac8f80-3cc3-4eee-ac26-7257d236e634)


# Checklist
- [ ] Tests
- [ ] Documentation
